### PR TITLE
Update cloudflared from 2024.6.1 to 2025.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # get the cloudflared image
-FROM cloudflare/cloudflared:2024.6.1 as cloudflared
+FROM cloudflare/cloudflared:2025.2.0 as cloudflared
 
 # take the alpine image
 FROM alpine:3.18.4


### PR DESCRIPTION
Bumped `cloudflare/cloudflared` from `2024.6.1` to `2025.2.0` to ensure we're using the latest stable release. 

This update includes security patches, performance improvements, and bug fixes - Keeping this package up to date helps maintain compatibility and enhances overall reliability. 

Please see attached release notes from cloudflared:

https://github.com/cloudflare/cloudflared/blob/d969fdec3eff5e925a409ad5b506441db72ca9b5/RELEASE_NOTES#L1-L145